### PR TITLE
bug: 태그 길어질 때 ui 깨짐 현상 해결 (#106) 배포

### DIFF
--- a/src/components/PostList/PostCard.jsx
+++ b/src/components/PostList/PostCard.jsx
@@ -19,6 +19,7 @@ import {
   CardBody,
   CardBottom,
   Line,
+  TagContent,
 } from './PostCardStyled';
 
 const PostCard = ({ post }) => {
@@ -37,6 +38,21 @@ const PostCard = ({ post }) => {
         return b.total - a.total;
       }),
   );
+
+  const handleTagsStyle = () => {
+    const tags = document.querySelectorAll('.tag_list');
+
+    tags.forEach((tag) => {
+      const tagChildren = tag.childNodes;
+      let tagWidth = 0;
+      tagChildren.forEach((child) => {
+        if (tagWidth + child.offsetWidth > 250) {
+          child.style.display = ' none';
+        }
+        tagWidth += child.offsetWidth + 8;
+      });
+    });
+  };
 
   useEffect(() => {
     switch (emoJiLen) {
@@ -59,6 +75,7 @@ const PostCard = ({ post }) => {
         setSecondEmoji(sortedFeedback[1].category);
         setSecondEmojiCount(sortedFeedback[1].total);
     }
+    handleTagsStyle();
   });
 
   return (
@@ -84,11 +101,11 @@ const PostCard = ({ post }) => {
             justifyContent: 'space-between',
           }}
         >
-          <div style={{ display: 'flex', marginLeft: '0.5rem', marginTop: '1rem' }}>
+          <TagContent className="tag_list">
             {Object.keys(post.tags).map((key) => (
               <Tag key={key}>{post.tags[key]}</Tag>
             ))}
-          </div>
+          </TagContent>
 
           <div
             style={{

--- a/src/components/PostList/PostCardStyled.js
+++ b/src/components/PostList/PostCardStyled.js
@@ -67,6 +67,13 @@ export const Content = styled.div`
         `}
 `;
 
+export const TagContent = styled.div`
+  display: flex;
+  margin-left: 0.5rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+`;
+
 export const Tag = styled.div`
   font-size: 0.8rem;
   margin-left: 0.5rem;

--- a/src/components/PostList/PostList.jsx
+++ b/src/components/PostList/PostList.jsx
@@ -186,9 +186,6 @@ const PostList = (props) => {
               <PostCard key={('postcard', index)} post={article[1]} />
             ))
           : loadArticlesDone && <PostNone>{postNoneMsg()}</PostNone>}
-        {/* {feedArticles.map((article, index) => (
-          <PostCard key={('postcard', index)} post={article[1]} />
-        ))} */}
       </PostCards>
     </Post>
   );


### PR DESCRIPTION
* feat: 카드 너비에 맞춰 tag 개수 return 해주는 함수 생성

* feat: 태그 width에 맞춰 자르기 (근데 로직이 이상함..고치는 중)

* fix: 함수 PostCard 내로 이동

* feat: 카드 너비에 맞춰 tag 자르기
